### PR TITLE
remove patch rpath option from `lib4bin`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
             cd AppDir
             wget "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin" -O ./lib4bin
             chmod +x ./lib4bin
-            xvfb-run -a -- ./lib4bin -p -v -e -r -k -w \
+            xvfb-run -a -- ./lib4bin -p -v -e -k -w \
               /usr/bin/pixelpulse2 \
               /usr/lib/$ARCH-linux-gnu/libvulkan* \
               /usr/lib/$ARCH-linux-gnu/libEGL* \


### PR DESCRIPTION
We found out this often breaks libraries, specially hardware acceleration with nvidia users, it also causes assertion errors with gtk3. 

This feature actually isn't needed. See explanations: 

https://github.com/probonopd/PrusaSlicer.AppImage/pull/2
https://github.com/Rosalie241/RMG/pull/345